### PR TITLE
Appsembler hawthorn devstack

### DIFF
--- a/docker-compose-watchers.yml
+++ b/docker-compose-watchers.yml
@@ -7,7 +7,7 @@ services:
     environment:
       BOK_CHOY_HOSTNAME: edx.devstack.lms_watcher
       ASSET_WATCHER_TIMEOUT: 12
-    image: edxops/edxapp:${OPENEDX_RELEASE:-latest}
+    image: appsembler/edxapp:${OPENEDX_RELEASE:-latest}
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
       - edxapp_lms_assets:/edx/var/edxapp/staticfiles/
@@ -19,7 +19,7 @@ services:
     environment:
       BOK_CHOY_HOSTNAME: edx.devstack.studio_watcher
       ASSET_WATCHER_TIMEOUT: 12
-    image: edxops/edxapp:${OPENEDX_RELEASE:-latest}
+    image: appsembler/edxapp:${OPENEDX_RELEASE:-latest}
     volumes:
       - edxapp_studio_assets:/edx/var/edxapp/staticfiles/
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
       BOK_CHOY_CMS_PORT: 18031
       EDXAPP_TEST_MONGO_HOST: edx.devstack.mongo
       NO_PYTHON_UNINSTALL: 1
-    image: edxops/edxapp:${OPENEDX_RELEASE:-latest}
+    image: appsembler/edxapp:${OPENEDX_RELEASE:-latest}
     ports:
       - "18000:18000"
       - "19876:19876" # JS test debugging
@@ -189,7 +189,7 @@ services:
       BOK_CHOY_CMS_PORT: 18131
       EDXAPP_TEST_MONGO_HOST: edx.devstack.mongo
       NO_PYTHON_UNINSTALL: 1
-    image: edxops/edxapp:${OPENEDX_RELEASE:-latest}
+    image: appsembler/edxapp:${OPENEDX_RELEASE:-latest}
     ports:
       - "18010:18010"
       - "19877:19877" # JS test debugging

--- a/provision-lms.sh
+++ b/provision-lms.sh
@@ -15,6 +15,9 @@ done
 
 docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PYTHON_UNINSTALL=1 paver install_prereqs'
 
+#Installing Appsembler specific requirements
+docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PYTHON_UNINSTALL=1 pip install --disable-pip-version-check --exists-action w -r requirements/edx/appsembler.txt'
+
 #Installing prereqs crashes the process
 docker-compose restart lms
 

--- a/provision-lms.sh
+++ b/provision-lms.sh
@@ -32,7 +32,8 @@ docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && python /ed
 docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms --settings=devstack_docker configure_commerce'
 
 # Create demo course and users
-docker-compose exec lms bash -c '/edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook /edx/app/edx_ansible/edx_ansible/playbooks/demo.yml -v -c local -i "127.0.0.1," --extra-vars="COMMON_EDXAPP_SETTINGS=devstack_docker"'
+# ND: commenting this because we don't need demo course
+# docker-compose exec lms bash -c '/edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook /edx/app/edx_ansible/edx_ansible/playbooks/demo.yml -v -c local -i "127.0.0.1," --extra-vars="COMMON_EDXAPP_SETTINGS=devstack_docker"'
 
 # Fix missing vendor file by clearing the cache
 docker-compose exec lms bash -c 'rm /edx/app/edxapp/edx-platform/.prereqs_cache/Node_prereqs.sha1'

--- a/repo.sh
+++ b/repo.sh
@@ -17,11 +17,7 @@ else
     exit 1
 fi
 
-if [ -n "${OPENEDX_RELEASE}" ]; then
-    OPENEDX_GIT_BRANCH=open-release/${OPENEDX_RELEASE}
-else
-    OPENEDX_GIT_BRANCH=master
-fi
+OPENEDX_GIT_BRANCH=open-release/hawthorn.master
 
 APPSEMBLER_EDX_PLATFORM_BRANCH="appsembler/tahoe/master"
 

--- a/repo.sh
+++ b/repo.sh
@@ -30,7 +30,7 @@ repos=(
     "https://github.com/edx/ecommerce.git"
     "https://github.com/edx/edx-e2e-tests.git"
     "https://github.com/edx/edx-notes-api.git"
-    "https://github.com/edx/edx-platform.git"
+    "https://github.com/appsembler/edx-platform.git"
     "https://github.com/edx/xqueue.git"
     "https://github.com/edx/edx-analytics-pipeline.git"
 )
@@ -40,7 +40,7 @@ private_repos=(
     "https://github.com/edx/edx-themes.git"
 )
 
-name_pattern=".*edx/(.*).git"
+name_pattern=".*(edx|appsembler)/(.*).git"
 
 _checkout ()
 {
@@ -51,7 +51,7 @@ _checkout ()
         # Use Bash's regex match operator to capture the name of the repo.
         # Results of the match are saved to an array called $BASH_REMATCH.
         [[ $repo =~ $name_pattern ]]
-        name="${BASH_REMATCH[1]}"
+        name="${BASH_REMATCH[2]}"
 
         # If a directory exists and it is nonempty, assume the repo has been cloned.
         if [ -d "$name" -a -n "$(ls -A "$name" 2>/dev/null)" ]; then
@@ -77,7 +77,7 @@ _clone ()
         # Use Bash's regex match operator to capture the name of the repo.
         # Results of the match are saved to an array called $BASH_REMATCH.
         [[ $repo =~ $name_pattern ]]
-        name="${BASH_REMATCH[1]}"
+        name="${BASH_REMATCH[2]}"
 
         # If a directory exists and it is nonempty, assume the repo has been checked out
         # and only make sure it's on the required branch
@@ -125,7 +125,7 @@ reset ()
     for repo in ${repos[*]}
     do
         [[ $repo =~ $name_pattern ]]
-        name="${BASH_REMATCH[1]}"
+        name="${BASH_REMATCH[2]}"
 
         if [ -d "$name" ]; then
             cd $name;git reset --hard HEAD;git checkout master;git reset --hard origin/master;git pull;cd "$currDir"
@@ -142,7 +142,7 @@ status ()
     for repo in ${repos[*]}
     do
         [[ $repo =~ $name_pattern ]]
-        name="${BASH_REMATCH[1]}"
+        name="${BASH_REMATCH[2]}"
 
         if [ -d "$name" ]; then
             printf "\nGit status for [%s]:\n" $name


### PR DESCRIPTION
Using this PR to hold work on getting devstack running using our version.

- [x] clone from `appsembler/edx-platform` instead of upstream
- [x]  `edx-platform` needs to checkout our hawthorn branch instead of `master`
- [x] docker images in the `docker-compose*.yml` files need to be switched from [edxop/edxapp]( https://hub.docker.com/r/edxops/edxapp/) to an Appsembler version, which we need to build (the `Dockerfile` is in `configuration`: https://github.com/edx/configuration/blob/master/docker/build/edxapp/Dockerfile