### PR TITLE
Misc hawthorn fixups and cleanup incl. freeze branches and add `npm install` to the Makefile static steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,13 +212,13 @@ xqueue_consumer-restart: ## Kill the XQueue development server. The watcher proc
 	docker exec -t edx.devstack.xqueue_consumer bash -c 'kill $$(ps aux | grep "manage.py run_consumer" | egrep -v "while|grep" | awk "{print \$$2}")'
 
 %-static: ## Rebuild static assets for the specified service container
-	docker exec -t edx.devstack.$* bash -c 'source /edx/app/$*/$*_env && cd /edx/app/$*/$*/ && make static'
+	docker exec -t edx.devstack.$* bash -c 'source /edx/app/$*/$*_env && cd /edx/app/$*/$*/ && npm install && make static'
 
 lms-static: ## Rebuild static assets for the LMS container
-	docker exec -t edx.devstack.lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && paver update_assets'
+	docker exec -t edx.devstack.lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && npm install && paver update_assets'
 
 studio-static: ## Rebuild static assets for the Studio container
-	docker exec -t edx.devstack.studio bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && paver update_assets'
+	docker exec -t edx.devstack.studio bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform/ && npm install && paver update_assets'
 
 static: | credentials-static discovery-static ecommerce-static lms-static studio-static ## Rebuild static assets for all service containers
 

--- a/provision-amc.py
+++ b/provision-amc.py
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-"""
-This file belongs to `appsembler/devstack` repo, only edit that version.
-Otherwise your changes will be overridden each time devstack is started.
-"""

--- a/repo.sh
+++ b/repo.sh
@@ -158,7 +158,7 @@ reset ()
             if [ "$name" == "edx-platform" ]; then
                 cd $name;git reset --hard HEAD;git checkout ${APPSEMBLER_EDX_PLATFORM_BRANCH};git reset --hard origin/${APPSEMBLER_EDX_PLATFORM_BRANCH};git pull;cd "$currDir"                
             else
-                cd $name;git reset --hard HEAD;git checkout master;git reset --hard origin/master;git pull;cd "$currDir"
+                cd $name;git reset --hard HEAD;git checkout open-release/hawthorn.master;git reset --hard origin/open-release/hawthorn.master;git pull;cd "$currDir"
             fi
         else
             printf "The [%s] repo is not cloned. Continuing.\n" $name


### PR DESCRIPTION
The two other commits are somewhat obvious, but ```
Add `npm install` to `make *-static` to fix stale npm requirements``` might be not. Therefore here's a bit of context: https://github.com/edx/devstack/pull/350