### PR TITLE
Support Figures

### DIFF
--- a/provision-tahoe.py
+++ b/provision-tahoe.py
@@ -55,6 +55,7 @@ def update_tahoe_env_with_tahoe_prefs(filename):
             'ENABLE_TIERS_APP': False,  # TODO: Fix the tiers app in devstack
             'ENABLE_CREATOR_GROUP': True,
             'DISABLE_COURSE_CREATION': False,
+            'FIGURES_IS_MULTISITE': True,
         })
 
         lms_env_encoded = json.dumps(env_object, ensure_ascii=False, indent=4).encode('utf-8')

--- a/tahoe.mk
+++ b/tahoe.mk
@@ -2,6 +2,7 @@ DEVSTACK_WORKSPACE ?= ..
 THEMES_DIR = $(DEVSTACK_WORKSPACE)/src/themes
 CUSTOMER_THEME_DIR = $(THEMES_DIR)/edx-theme-codebase/customer_specific
 AMC_DIR = $(DEVSTACK_WORKSPACE)/amc
+FIGURES_DIR = $(DEVSTACK_WORKSPACE)/src/figures
 
 UNAME_S := $(shell uname -s)
 LINUX_CMD ?= true
@@ -58,6 +59,7 @@ tahoe.theme.reset:  ## Removes and re-clone the theme with Tahoe branches
 tahoe.init.provision-script:  ## Execute the `provision-tahoe.py` script in both of LMS and Studio
 	cat $(DEVSTACK_WORKSPACE)/devstack/provision-tahoe.py > $(DEVSTACK_WORKSPACE)/src/provision-tahoe.py
 	make COMMAND='python /edx/src/provision-tahoe.py' tahoe.exec.edxapp
+	make COMMAND='pip install -e /edx/src/figures' SERVICE=lms tahoe.exec.single
 	rm $(DEVSTACK_WORKSPACE)/src/provision-tahoe.py
 
 tahoe.init:  ## Make the devstack more Tahoe'ish
@@ -66,6 +68,7 @@ tahoe.init:  ## Make the devstack more Tahoe'ish
 
 tahoe.up:  ## Run the devstack with proper Tahoe settings, use instead of `$ make dev.up`
 	make tahoe.chown
+	test -d $(FIGURES_DIR) || make tahoe.figures
 	make dev.up
 	@sleep 1
 	make tahoe.init
@@ -81,6 +84,11 @@ tahoe.envs.reset:  ## Reset the JSON envs
 	make down
 	make tahoe.envs._delete
 	make tahoe.up
+
+tahoe.figures:  ## Install Figures
+	make COMMAND='rm -rf /edx/src/figures' SERVICE=lms tahoe.exec.single
+	git clone -b omar/no-fork git@github.com:appsembler/figures.git $(FIGURES_DIR)
+	make lms-update-db
 
 tahoe.reset.light:  ## Resets the Tahoe settings including a fresh theme copy and new environment files.
 	make down

--- a/tahoe.mk
+++ b/tahoe.mk
@@ -87,7 +87,7 @@ tahoe.envs.reset:  ## Reset the JSON envs
 
 tahoe.figures:  ## Install Figures
 	make COMMAND='rm -rf /edx/src/figures' SERVICE=lms tahoe.exec.single
-	git clone -b omar/no-fork git@github.com:appsembler/figures.git $(FIGURES_DIR)
+	git clone -b develop git@github.com:appsembler/figures.git $(FIGURES_DIR)
 	make lms-update-db
 
 tahoe.reset.light:  ## Resets the Tahoe settings including a fresh theme copy and new environment files.


### PR DESCRIPTION
Add steps and default settings to support Figures on Tahoe devstack.

Currently this PR uses the branch `omar/no-fork` branch of https://github.com/appsembler/figures/pull/84

### TODO
 - [x] Let's keep it unmerged until we get both https://github.com/appsembler/figures/pull/84 and it's parent https://github.com/appsembler/figures/pull/82 merged into `develop` so we can use that branch.