### PR TITLE
allow postgres and redis ports to be overridden

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,13 +215,13 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
-      - 5432:5432
+      - ${POSTGRES_PORT}:5432
 
   redis:
     image: redis:3.0
     container_name: tahoe.devstack.redis
     ports:
-      - 6379:6379
+      - ${REDIS_PORT}:6379
     volumes:
       - redis_data:/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,7 +221,7 @@ services:
     image: redis:3.0
     container_name: tahoe.devstack.redis
     ports:
-      - ${REDIS_PORT}:6379
+      - ${TAHOE_REDIS_PORT}:6379
     volumes:
       - redis_data:/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,7 +215,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
-      - ${POSTGRES_PORT}:5432
+      - ${TAHOE_POSTGRES_PORT}:5432
 
   redis:
     image: redis:3.0

--- a/port_defaults.mk
+++ b/port_defaults.mk
@@ -5,7 +5,7 @@
 # have services running locally
 
 TAHOE_POSTGRES_PORT ?= 5432
-REDIS_PORT ?= 6379
+TAHOE_REDIS_PORT ?= 6379
 
-export POSTGRES_PORT
-export REDIS_PORT
+export TAHOE_POSTGRES_PORT
+export TAHOE_REDIS_PORT

--- a/port_defaults.mk
+++ b/port_defaults.mk
@@ -1,0 +1,11 @@
+# define external port default values here
+# these can be overridden at the commandline
+# (eg, `REDIS_PORT=16739 make tahoe.up`) or in a .env file
+# this is useful to avoid port conflicts if you already
+# have services running locally
+
+POSTGRES_PORT ?= 5432
+REDIS_PORT ?= 6379
+
+export POSTGRES_PORT
+export REDIS_PORT

--- a/port_defaults.mk
+++ b/port_defaults.mk
@@ -4,7 +4,7 @@
 # this is useful to avoid port conflicts if you already
 # have services running locally
 
-POSTGRES_PORT ?= 5432
+TAHOE_POSTGRES_PORT ?= 5432
 REDIS_PORT ?= 6379
 
 export POSTGRES_PORT


### PR DESCRIPTION
I run local instances of these services already, so exposing the default ports causes a conflict. This makes them variables that can be overridden by environment variables.

For completeness, I guess we could do all of the ports this way, but the most likely conflicts are these commonly used ports.