### PR TITLE
Put uploads in a volume so it stays after restart

### DIFF
--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -20,6 +20,8 @@ services:
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
       - edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules
+      - edxapp_media:/edx/var/edxapp/media
+      - edxapp_uploads:/edx/var/edxapp/uploads
       - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
       - ${DEVSTACK_WORKSPACE}/customer_themes:/edx/var/edxapp/themes/customer_themes:cached
       - ${DEVSTACK_WORKSPACE}/edx-theme-codebase:/edx/var/edxapp/themes/edx-theme-codebase:cached
@@ -32,6 +34,8 @@ services:
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
       - edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules
+      - edxapp_media:/edx/var/edxapp/media
+      - edxapp_uploads:/edx/var/edxapp/uploads
       - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
       - ${DEVSTACK_WORKSPACE}/customer_themes:/edx/var/edxapp/themes/customer_themes:cached
       - ${DEVSTACK_WORKSPACE}/edx-theme-codebase:/edx/var/edxapp/themes/edx-theme-codebase:cached
@@ -51,3 +55,5 @@ volumes:
   discovery_node_modules:
   ecommerce_node_modules:
   edxapp_node_modules:
+  edxapp_media:
+  edxapp_uploads:


### PR DESCRIPTION
This is a quick win and fairly not risky to get merged. I need a single reviewer for this pull request.

So this has come up often for @grozdanowski but I just kept forgetting about it. 

### Steps to Reproduce

 - Open <http://localhost:19000/app/appearance-settings/logo-assets> 
 - Upload a logo
 - Make sure it shows up in `$ edxapp ls -v /edx/var/edxapp/{media,uploads}`
 - Take the devstack down: `$ make down`
 - Run the devstack again: `$ make tahoe.up`
 - Again, run `$ edxapp ls -v /edx/var/edxapp/{media,uploads}`
 - Refresh <http://localhost:19000/app/appearance-settings/logo-assets> 

### Expected
 - The file to show up in AMC and on the file system

### Actual
 - The file gets lost after a docker restart