### PR TITLE
Allow disabling docker volumes cache for better consistency but slower performance

### DIFF
--- a/docker-compose-host.yml
+++ b/docker-compose-host.yml
@@ -3,25 +3,25 @@ version: "2.1"
 services:
   lms:
     volumes:
-      - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
+      - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:${DEVSTACK_CACHE:-cached}
       - edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules
       - edxapp_media:/edx/var/edxapp/media
       - edxapp_uploads:/edx/var/edxapp/uploads
-      - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
-      - ${DEVSTACK_WORKSPACE}/customer_themes:/edx/var/edxapp/themes/customer_themes:cached
-      - ${DEVSTACK_WORKSPACE}/edx-theme-codebase:/edx/var/edxapp/themes/edx-theme-codebase:cached
+      - ${DEVSTACK_WORKSPACE}/src:/edx/src:${DEVSTACK_CACHE:-cached}
+      - ${DEVSTACK_WORKSPACE}/customer_themes:/edx/var/edxapp/themes/customer_themes:${DEVSTACK_CACHE:-cached}
+      - ${DEVSTACK_WORKSPACE}/edx-theme-codebase:/edx/var/edxapp/themes/edx-theme-codebase:${DEVSTACK_CACHE:-cached}
   studio:
     volumes:
-      - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
+      - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:${DEVSTACK_CACHE:-cached}
       - edxapp_node_modules:/edx/app/edxapp/edx-platform/node_modules
       - edxapp_media:/edx/var/edxapp/media
       - edxapp_uploads:/edx/var/edxapp/uploads
-      - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
-      - ${DEVSTACK_WORKSPACE}/customer_themes:/edx/var/edxapp/themes/customer_themes:cached
-      - ${DEVSTACK_WORKSPACE}/edx-theme-codebase:/edx/var/edxapp/themes/edx-theme-codebase:cached
+      - ${DEVSTACK_WORKSPACE}/src:/edx/src:${DEVSTACK_CACHE:-cached}
+      - ${DEVSTACK_WORKSPACE}/customer_themes:/edx/var/edxapp/themes/customer_themes:${DEVSTACK_CACHE:-cached}
+      - ${DEVSTACK_WORKSPACE}/edx-theme-codebase:/edx/var/edxapp/themes/edx-theme-codebase:${DEVSTACK_CACHE:-cached}
   amc:
     volumes:
-      - ${DEVSTACK_WORKSPACE}/amc:/opt/amc:cached
+      - ${DEVSTACK_WORKSPACE}/amc:/opt/amc:${DEVSTACK_CACHE:-cached}
 
 volumes:
   credentials_node_modules:

--- a/docker-compose-watchers.yml
+++ b/docker-compose-watchers.yml
@@ -9,9 +9,9 @@ services:
       ASSET_WATCHER_TIMEOUT: 12
     image: appsembler/edxapp:latest  # Will work fine until we have Ironwood
     volumes:
-      - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
+      - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:${DEVSTACK_CACHE:-cached}
       - edxapp_lms_assets:/edx/var/edxapp/staticfiles/
-      - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
+      - ${DEVSTACK_WORKSPACE}/src:/edx/src:${DEVSTACK_CACHE:-cached}
 
   studio_watcher:
     command: bash -c 'cd /edx/app/edxapp/edx-platform && source ../edxapp_env && while true; do paver watch_assets --w=$$ASSET_WATCHER_TIMEOUT; sleep 2; done'
@@ -22,8 +22,8 @@ services:
     image: appsembler/edxapp:latest  # Will work fine until we have Ironwood
     volumes:
       - edxapp_studio_assets:/edx/var/edxapp/staticfiles/
-      - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:cached
-      - ${DEVSTACK_WORKSPACE}/src:/edx/src:cached
+      - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:${DEVSTACK_CACHE:-cached}
+      - ${DEVSTACK_WORKSPACE}/src:/edx/src:${DEVSTACK_CACHE:-cached}
 
 volumes:
   edxapp_lms_assets:

--- a/docker-compose-xqueue.yml
+++ b/docker-compose-xqueue.yml
@@ -6,7 +6,7 @@ services:
     image: edxops/xqueue:hawthorn.master
     command: bash -c 'source /edx/app/xqueue/xqueue_env && while true; do python /edx/app/xqueue/xqueue/manage.py runserver 0.0.0.0:18040 ; sleep 2; done'
     volumes:
-      - ${DEVSTACK_WORKSPACE}/xqueue:/edx/app/xqueue/xqueue:cached
+      - ${DEVSTACK_WORKSPACE}/xqueue:/edx/app/xqueue/xqueue:${DEVSTACK_CACHE:-cached}
     # depends_on: even though we need mysql, we can't refer to it because it's started in the other compose file
     ports:
       - 18040:18040
@@ -16,5 +16,5 @@ services:
     image: edxops/xqueue:hawthorn.master
     command: bash -c 'source /edx/app/xqueue/xqueue_env && while true; do python /edx/app/xqueue/xqueue/manage.py run_consumer ; sleep 2; done'
     volumes:
-      - ${DEVSTACK_WORKSPACE}/xqueue:/edx/app/xqueue/xqueue:cached
+      - ${DEVSTACK_WORKSPACE}/xqueue:/edx/app/xqueue/xqueue:${DEVSTACK_CACHE:-cached}
     # depends_on: even though we need mysql, we can't refer to it because it's started in the other compose file


### PR DESCRIPTION
Hopefully to solve filesystem inconsistency for @johnbaldwin 

Let's see what the edX folks let us know about the issue:

 - https://openedx.slack.com/team/U1ERLTPNX

Now it's possible to use `export DEVSTACK_CACHE='default'` or any other value in the `.bashrc` to experiment with different cache settings.