### PR TITLE
Lightweight devstack for Tahoe

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Requirements
 Desclaimer
 ----------
 - Apparently Docker behavior is inconsistent between Mac and Linux due to some core differences between both operating systems.
-- This README.md contains some known bugs and issues, make sure to search your issues here as they might be an issue we ran into before. 
+- This README contains some known bugs and issues, make sure to search your issues here as they might be an issue we ran into before.
 
 .. code::
 
@@ -32,10 +32,10 @@ Tahoe is all about subdomains, so please add the following entries to your ``/et
 
 .. code::
 
+    127.0.0.1 edx.devstack.lms
     127.0.0.1 red.localhost
     127.0.0.1 blue.localhost
     127.0.0.1 green.localhost
-    127.0.0.1 edx.devstack.lms
 
 
 Using Tahoe and AMC
@@ -78,6 +78,8 @@ Currently the commands looks like this:
 .. code::
 
     $ make help | grep -e tahoe -e amc
+      tahoe.up                  Run the lightweight devstack with proper Tahoe settings, use instead of `$ make dev.up`
+      tahoe.up.full             Run the full devstack with proper Tahoe settings, use instead of `$ make dev.up`
       amc.provision             Initializes the AMC
       tahoe.chown               Fix annoying docker permission issues
       tahoe.envs._delete        Remove settings, in prep for resetting it
@@ -85,10 +87,9 @@ Currently the commands looks like this:
       tahoe.exec.single         Execute a command inside a devstack docker container
       tahoe.provision           Make the devstack more Tahoe'ish
       tahoe.restart             Restarts both of LMS and Studio python processes while keeping the same container
-      tahoe.up                  Run the devstack with proper Tahoe settings, use instead of `$ make dev.up`
 
 
-If something goes wrong, check the rest of this README for additional details.
+If something goes wrong, check out the rest of this README for additional details.
 
 Environment Files
 -----------------

--- a/docker-compose-tahoe.yml
+++ b/docker-compose-tahoe.yml
@@ -1,0 +1,30 @@
+# This file is used by Tahoe to make a lightweight startup for `$ make tahoe.up`
+# For the full version, use `$ make tahoe.up.full`
+
+version: "2.1"
+
+services:
+  chrome:
+    image: hello-world
+    command: /hello
+  elasticsearch:
+    image: hello-world
+    command: /hello
+  firefox:
+    image: hello-world
+    command: /hello
+  credentials:
+    image: hello-world
+    command: /hello
+  discovery:
+    image: hello-world
+    command: /hello
+  ecommerce:
+    image: hello-world
+    command: /hello
+  edx_notes_api:
+    image: hello-world
+    command: /hello
+  forum:
+    image: hello-world
+    command: /hello

--- a/tahoe.mk
+++ b/tahoe.mk
@@ -18,7 +18,7 @@ tahoe.provision:  ## Make the devstack more Tahoe'ish
 	rm $(DEVSTACK_WORKSPACE)/src/provision-tahoe.py
 	make tahoe.restart || true
 
-tahoe.up:  ## Run the partial devstack with proper Tahoe settings, use instead of `$ make dev.up`
+tahoe.up:  ## Run the lightweight devstack with proper Tahoe settings, use instead of `$ make dev.up`
 	bash -c 'docker-compose -f docker-compose.yml -f docker-compose-host.yml -f docker-compose-tahoe.yml up -d'
 	@sleep 1
 	make tahoe.provision

--- a/tahoe.mk
+++ b/tahoe.mk
@@ -18,7 +18,13 @@ tahoe.provision:  ## Make the devstack more Tahoe'ish
 	rm $(DEVSTACK_WORKSPACE)/src/provision-tahoe.py
 	make tahoe.restart || true
 
-tahoe.up:  ## Run the devstack with proper Tahoe settings, use instead of `$ make dev.up`
+tahoe.up:  ## Run the partial devstack with proper Tahoe settings, use instead of `$ make dev.up`
+	bash -c 'docker-compose -f docker-compose.yml -f docker-compose-host.yml -f docker-compose-tahoe.yml up -d'
+	@sleep 1
+	make tahoe.provision
+	make tahoe.chown
+
+tahoe.up.full:  ## Run the full devstack with proper Tahoe settings, use instead of `$ make dev.up`
 	make dev.up
 	@sleep 1
 	make tahoe.provision


### PR DESCRIPTION
So this should make the Macbooks happier.

Well it's mostly Docker's fault for being so heavy on Mac.

Also, it turns out that the AMC frontend is super heavy. But this should fix the problem anyway.

### How does this work?

Well, this utilizes the Docker Compose yaml overrides. It replaces the unwanted files with the `hello-world` image that is super lightweight.

While retaining the possibility to run the full devstack via `$ make tahoe.up.full`, but I did not bother testing this! I don't think we'll need those anyway!

### What's exactly being removed?

All of the following services:

 - chrome
 - **elasticsearch**
 - firefox
 - credentials
 - discovery
 - **ecommerce**
 - edx_notes_api
 - **forum**

### Even forum? 

Yes, because Matej and Maxi don't care about it so I want to make their life easier.