### PR TITLE
(WIP) tahoe.up Optimization: Avoid restarting to save time

### DIFF
--- a/provision-tahoe.py
+++ b/provision-tahoe.py
@@ -32,7 +32,7 @@ def move_environment_files_to_host():
         if not src_path.exists():
             if container_path.islink():
                 raise Exception(
-                    'Unable to correctly move the environmet files, please shut down the '
+                    'Unable to correctly move the environment files, please shut down the '
                     'container `$ make down` and try again with `$ make tahoe.up`'
                 )
 

--- a/tahoe.mk
+++ b/tahoe.mk
@@ -16,11 +16,9 @@ tahoe.provision:  ## Make the devstack more Tahoe'ish
 	cat $(DEVSTACK_WORKSPACE)/devstack/provision-tahoe.py > $(DEVSTACK_WORKSPACE)/src/provision-tahoe.py
 	make COMMAND='python /edx/src/provision-tahoe.py' tahoe.exec.edxapp
 	rm $(DEVSTACK_WORKSPACE)/src/provision-tahoe.py
-	make tahoe.restart || true
 
 tahoe.up:  ## Run the lightweight devstack with proper Tahoe settings, use instead of `$ make dev.up`
 	bash -c 'docker-compose -f docker-compose.yml -f docker-compose-host.yml -f docker-compose-tahoe.yml up -d'
-	@sleep 1
 	make tahoe.provision
 	make tahoe.chown
 


### PR DESCRIPTION
Somewhat risky change. But with some testing we can see if it's working well on Mac.

This should reduce the infamous 10-minutes startup time for `$ make tahoe.up`