### PR TITLE
Enabling Hot Module Reloading

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Using Tahoe and AMC
 
 The project is now available on the following URLs:
 
-- **AMC:** http://localhost:19000/
+- **AMC:** http://localhost:13000/
 - **Studio:** http://localhost:18010/
     - This will not work until you finish section setting up your env as shown in `But, But, But Where's My Site? <https://github.com/appsembler/devstack#but-but-but-wheres-my-site>`_    
     - If AMC says it's http://studio.localhost:18000 that's a bug, just use the former URL.
@@ -61,7 +61,7 @@ But, But, But Where's My Site?
 
 `Until we automate that <https://trello.com/c/wS5rTBFp>`_ you have to create the site manually. It's not that hard:
 
-- Go to http://localhost:19000/signup-wizard/0
+- Go to http://localhost:13000/signup-wizard/0
 - Follow the steps setting the site name to ``red`` so it matches the earlier ``/etc/hosts`` entries.
 - In the terminal run ``$ make logs`` scroll up to activate your email
 - This is a shortcut if you don't like scrolling: ``$ make logs | grep devstack.amc | grep -o 'http:.*accounts/confirm-email/[^/]*/' | tail -n1``

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -263,8 +263,11 @@ services:
     tty: true
     environment:
       LMS_BASE: "localhost:18000"
-      PORT: "13000"
-      HOST: ${HOST:-0.0.0.0}
+      PORT: 13000
+      HOST: ${HOST:-localhost}
+      BACKEND_HOST: "http://tahoe.devstack.amc:19000"
+    depends_on:
+      - amc
     image: gcr.io/appsembler-tahoe-0/amc-frontend
     ports:
       - "13000:13000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -253,7 +253,7 @@ services:
       APPSEMBLER_SECRET_KEY: secret_key
     image: gcr.io/appsembler-tahoe-0/amc
     ports:
-      - "19000:19000"
+      - "29000:19000"  # Discourage the use of the Python backend, but make it available for debugging purposes
 
   amc-frontend:
     command: bash -c 'while true; do npm start; sleep 2; done'


### PR DESCRIPTION
HMR was broken when we moved to the Docker devstack. This PR brings it back as long as it's opened on the new URL:

 - http://localhost:13000/app/

### How to test it?

Checkout AMC at the branch of https://github.com/appsembler/amc/pull/255 and watch the HTML/JavaScript changes without needing to reload the server.