### PR TITLE
Bump mongo to 3.6.17 so it works after the Atlas upgrade

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     # See https://docs.mongodb.com/v3.0/reference/program/mongod/#options for complete details.
     command: mongod --smallfiles --nojournal --storageEngine wiredTiger
     container_name: edx.devstack.mongo
-    image: mongo:3.2.16
+    image: mongo:3.6.17
     ports:
      - "27017:27017"
     volumes:


### PR DESCRIPTION
So it works after the Atlas related upgrades in the edX Platform (https://github.com/appsembler/edx-platform/pull/503).