### PR TITLE
URL and docker image fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -212,6 +212,8 @@ services:
   postgres:
     image: postgres:9.4
     container_name: tahoe.devstack.postgres
+    environment:
+      POSTGRES_PASSWORD: 'postgres'
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -251,7 +251,7 @@ services:
       OAUTHLIB_INSECURE_TRANSPORT: "true"
       APPSEMBLER_EDX_API_KEY: test
       APPSEMBLER_SECRET_KEY: secret_key
-    image: gcr.io/appsembler-tahoe-0/amc
+    image: appsembler/amc-backend-base
     ports:
       - "29000:19000"  # Discourage the use of the Python backend, but make it available for debugging purposes
 
@@ -268,7 +268,7 @@ services:
       BACKEND_HOST: "http://tahoe.devstack.amc:19000"
     depends_on:
       - amc
-    image: gcr.io/appsembler-tahoe-0/amc-frontend
+    image: appsembler/amc-frontend-base
     ports:
       - "13000:13000"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -242,7 +242,7 @@ services:
       DATABASE_URL: "postgres://postgres:postgres@tahoe.devstack.postgres:5432/postgres"
       BROKER_URL: "redis://tahoe.devstack.redis:6379/1"
       LMS_BASE_URL: "http://edx.devstack.lms:18000"
-      CMS_BASE_URL: "http://tahoe.devstack.studio:18010"
+      CMS_BASE_URL: "http://edx.devstack.studio:18010"
       APPSEMBLER_EDX_OAUTH_CLIENT_ID: 6f2b93d5c02560c3f93f
       APPSEMBLER_EDX_OAUTH_CLIENT_SECRET: 2c6c9ac52dd19d7255dd569fb7eedbe0ebdab2db
       DJANGO_SETTINGS_MODULE: config.settings

--- a/provision-tahoe.py
+++ b/provision-tahoe.py
@@ -62,7 +62,7 @@ def install_auto_pip_requirements():
     for package_dir in PIP_DIR.dirs():
         setup_file = package_dir / 'setup.py'
         if setup_file.exists():  # Ensure it's a proper Python package.
-            call(['pip', 'install', '-e', package_dir])
+            call(['pip', 'install', '--no-deps', '-e', package_dir])
 
 
 def main():


### PR DESCRIPTION
Fixes for destack:

  - Fix internal studio URL
  - Use public gcr.io docker images for AMC to avoid authentication issues

### TODO:

 - [x] Get the AMC docker PR (https://github.com/appsembler/amc/pull/304) merged
 - [x] Push the images to ~grc.io~ Docker Hub
 - [ ] Delete the old `amc` and `amc-frontend` images
 - [ ] Get :+1: and merge