### PR TITLE
Use hawthorn Docker image for note to fix provision errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,7 +159,7 @@ services:
       - devpi
       - elasticsearch
       - mysql
-    image: edxops/notes:latest  # Will work fine until we have Ironwood
+    image: edxops/notes:hawthorn.master  # Will work fine until we have Ironwood
     ports:
       - "18120:18120"
     environment:


### PR DESCRIPTION
Otherwise `$ make dev.provision` will break due to changes in the `edxops/notes:latest` docker image. 

**Note:** It should have been done in https://github.com/appsembler/devstack/commit/f1f538ccea7c7b41b955ae90455159bcc8e53cdb but apparently I forgot to do that.