### PR TITLE
use hawthorn tagged images instead of latest

### DIFF
--- a/docker-compose-watchers.yml
+++ b/docker-compose-watchers.yml
@@ -7,7 +7,7 @@ services:
     environment:
       BOK_CHOY_HOSTNAME: edx.devstack.lms_watcher
       ASSET_WATCHER_TIMEOUT: 12
-    image: appsembler/edxapp:latest  # Will work fine until we have Ironwood
+    image: appsembler/edxapp:hawthorn
     volumes:
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:${DEVSTACK_CACHE:-cached}
       - edxapp_lms_assets:/edx/var/edxapp/staticfiles/
@@ -19,7 +19,7 @@ services:
     environment:
       BOK_CHOY_HOSTNAME: edx.devstack.studio_watcher
       ASSET_WATCHER_TIMEOUT: 12
-    image: appsembler/edxapp:latest  # Will work fine until we have Ironwood
+    image: appsembler/edxapp:hawthorn
     volumes:
       - edxapp_studio_assets:/edx/var/edxapp/staticfiles/
       - ${DEVSTACK_WORKSPACE}/edx-platform:/edx/app/edxapp/edx-platform:${DEVSTACK_CACHE:-cached}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
       BOK_CHOY_CMS_PORT: 18031
       EDXAPP_TEST_MONGO_HOST: edx.devstack.mongo
       NO_PYTHON_UNINSTALL: 1
-    image: appsembler/edxapp:latest  # Will work fine until we have Ironwood
+    image: appsembler/edxapp:hawthorn
     ports:
       - "18000:18000"
       - "19876:19876" # JS test debugging
@@ -189,7 +189,7 @@ services:
       BOK_CHOY_CMS_PORT: 18131
       EDXAPP_TEST_MONGO_HOST: edx.devstack.mongo
       NO_PYTHON_UNINSTALL: 1
-    image: appsembler/edxapp:latest # Will work fine until we have Ironwood
+    image: appsembler/edxapp:hawthorn
     ports:
       - "18010:18010"
       - "19877:19877" # JS test debugging


### PR DESCRIPTION
eliminate impending conflict as we work on Juniper.

This will require https://github.com/appsembler/configuration/pull/328 to be merged to create an up to date hawthorn image.