### PR TITLE
Provisioning fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -285,10 +285,7 @@ services:
       - mysql
       - memcached
       - mongo
-      - discovery
       - forum
-      - firefox
-      - chrome
     # Allows attachment to the LMS service using 'docker attach <containerID>'.
     stdin_open: true
     tty: true
@@ -317,7 +314,6 @@ services:
     container_name: "edx.${COMPOSE_PROJECT_NAME:-devstack}.registrar"
     hostname: registrar.devstack.edx
     depends_on:
-      - discovery
       - lms
       - mysql
       - memcached
@@ -394,8 +390,6 @@ services:
       - mysql
       - memcached
       - mongo
-      - firefox
-      - chrome
       - lms
     # Allows attachment to the Studio service using 'docker attach <containerID>'.
     stdin_open: true

--- a/options.mk
+++ b/options.mk
@@ -47,7 +47,7 @@ FS_SYNC_STRATEGY ?= local-mounts
 # TODO: Re-evaluate this list and consider paring it down to a tighter core.
 #       The current value was chosen such that it would not change the existing
 #       Devstack behavior.
-DEFAULT_SERVICES ?= lms+studio+ecommerce+discovery+credentials+forum+edx_notes_api+gradebook+frontend-app-publisher
+DEFAULT_SERVICES ?= lms+studio+credentials+forum+edx_notes_api+gradebook+frontend-app-publisher
 
 # List of all services with database migrations.
 # Services must provide a Makefile target named: $(service)-update-db

--- a/provision-lms.sh
+++ b/provision-lms.sh
@@ -15,10 +15,10 @@ done
 
 docker-compose $DOCKER_COMPOSE_FILES exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PYTHON_UNINSTALL=1 paver install_prereqs'
 
-#Installing Appsembler specific requirements
+# Installing Appsembler specific requirements
 docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PYTHON_UNINSTALL=1 pip install --disable-pip-version-check --exists-action w -r requirements/edx/appsembler.txt'
 
-#Installing prereqs crashes the process
+# Installing prereqs crashes the process
 docker-compose restart lms
 
 # Run edxapp migrations first since they are needed for the service users and OAuth clients

--- a/repo.sh
+++ b/repo.sh
@@ -19,7 +19,7 @@ fi
 
 OPENEDX_GIT_BRANCH=open-release/juniper.3
 
-APPSEMBLER_EDX_PLATFORM_BRANCH="appsembler/tahoe/develop"
+APPSEMBLER_EDX_PLATFORM_BRANCH="main"
 AMC_BRANCH="develop"
 THEME_CODEBASE_BRANCH="hawthorn/master"  # we don't have a juniper branch yet
 THEME_CUSTOMERS_BRANCH="hawthorn/tahoe"  # we don't have a juniper branch yet
@@ -58,7 +58,7 @@ ssh_repos=(
     "git@github.com:edx/ecommerce.git"
     "git@github.com:edx/edx-e2e-tests.git"
     "git@github.com:edx/edx-notes-api.git"
-    "git@github.com:edx/edx-platform.git"
+    "git@github.com:appsembler/edx-platform.git"
     "git@github.com:edx/xqueue.git"
     "git@github.com:edx/edx-analytics-pipeline.git"
     "git@github.com:edx/frontend-app-gradebook.git"
@@ -137,7 +137,7 @@ _clone ()
             fi
             printf "The [%s] repo is already checked out. Checking for updates.\n" "$name"
             cd "${DEVSTACK_WORKSPACE}/${name}"
-            _checkout_and_update_branch
+            _appsembler_checkout_and_update_branch $name
             cd ..
         elif [ "$name" == "edx-theme-customers" -a -d "edx-theme-codebase/customer_specific/.git" ]; then
             cd "${DEVSTACK_WORKSPACE}/edx-theme-codebase/customer_specific"


### PR DESCRIPTION
This solves few crashes on the Juniper branch during provisioning the devstack.

- Removes some docker services that are not used in Appsembler Devstack.
- Updates Appsembler main branch.
- Uses `_appsembler_checkout_and_update_branch` instead of edX's `_checkout_and_update_branch`.
- Updates edx-platform repo url.

How to test?
On your machine (or the remote machine) with a cloned devstack and a Python3 virtual env:

```console
$ cd devstack
$ export DEVSTACK_WORKSPACE=/path/to/workspace  ## devstack parent directory
$ export VIRTUAL_ENV=$DEVSTACK_WORKSPACE/env
$ export OPENEDX_RELEASE=juniper.master

$ source $VIRTUAL_ENV/bin/activate

$ make requirements
$ make dev.clone
$ make dev.pull

$ make dev.provision
```

What to expect?
- **Module beeline not found**: This is fixed on edx-platform side here: [#798](https://github.com/appsembler/edx-platform/pull/798)
- **Theme directory issue**: To be solved later on edx-platform.
