### PR TITLE
expose mongodb port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,8 +108,8 @@ services:
       default:
         aliases:
           - edx.devstack.mongo
-    # ports:
-    #  - "27017:27017"
+    ports:
+      - "27017:27017"
     volumes:
       - mongo_data:/data/db
 


### PR DESCRIPTION
this has been enabled on hawthorn but got lost during the merge