### PR TITLE
Remove default site creation commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,16 +43,30 @@ Tahoe is all about subdomains, so please add the following entries to your ``/et
 
     127.0.0.1 edx.devstack.lms  # Needed for devstack nascence
     127.0.0.1 red.localhost  # Your default site
-    127.0.0.1 blue.localhost green.localhost  # Create as many of those as you wish
+    127.0.0.1 blue.devstack.tahoe green.devstack.tahoe  # Create as many of those as you wish
 
 Where's my Site?
 ----------------
+To create a new site, please run the following commands in your devstack host:
 
-Now you have a site of your own:
+.. code::
 
-  - **LMS:** http://red.localhost:18000/
-  - **Studio:** http://localhost:18010/
-  - **AMC:** http://localhost:13000/
+    $ make lms-shell
+    $ python manage.py lms create_devstack_site <org> <hostname>
+    $ make amc-shell
+    $ python manage.py create_devstack_site <org> <hostname>
+
+
+
+**Note**
+``hostname`` should be ``localhost`` if your devstack is hosted locally, or any value from ``EDX_HOST_NAMES`` if you are using `Sultan <https://github.com/appsembler/sultan/blob/master/configs/.configs#L81>`_.
+
+
+Then you'll have a site of your own:
+
+  - **LMS:** http://<org>.<hostname>:18000/
+  - **Studio:** http://<hostname>:18010/
+  - **AMC:** http://<hostname>:13000/
 
 Credentials are:
 

--- a/tahoe.mk
+++ b/tahoe.mk
@@ -33,9 +33,7 @@ tahoe.restart:  ## Restarts both of LMS and Studio python processes while keepin
 amc.provision:  ## Initializes the AMC
 	docker exec -it tahoe.$(COMPOSE_PROJECT_NAME).amc python manage.py migrate
 	make COMMAND='python manage.py lms create_dot_application --grant-type password --redirect-uris=http://localhost:13000 --skip-authorization --client-id=6f2b93d5c02560c3f93f --client-secret=2c6c9ac52dd19d7255dd569fb7eedbe0ebdab2db AMC edx' SERVICE='lms' tahoe.exec.single
-	make COMMAND='python manage.py lms create_devstack_site red' SERVICE='lms' tahoe.exec.single
 	docker exec -it tahoe.$(COMPOSE_PROJECT_NAME).amc python manage.py create_devstack_superuser
-	docker exec -it tahoe.$(COMPOSE_PROJECT_NAME).amc python manage.py create_devstack_site red
 	docker exec -it tahoe.$(COMPOSE_PROJECT_NAME).amc-frontend npm install
 
 amc.activation_links:  ## List activation links from the AMC log


### PR DESCRIPTION
### Overview

#### What sparked this PR? 
When I tried to setup a new devstack and provision it, it failed on `create_devstack_site` because of the recent change on `create_devstack_site` in [amc#472](https://github.com/appsembler/amc/pull/472) and [edx-platform#848](https://github.com/appsembler/edx-platform/pull/848)

#### What problem does it solve? 
- Provisioning the devstack no longer should fail.
- Closer to edX changes.

#### Related PRs
- [sultan#56](https://github.com/appsembler/sultan/pull/56)

### Release notes 

- Bug fixes.

### Other 
- [x] Docs?
~- [ ] Tests?~
