### PR TITLE
Juniper: support for shared devstack configurations

### DIFF
--- a/provision-tahoe.py
+++ b/provision-tahoe.py
@@ -3,8 +3,6 @@
 This file belongs to `appsembler/devstack` repo, only edit that version.
 Otherwise your changes will be overridden each time devstack is started.
 """
-from os import makedirs
-from shutil import move
 from path import Path
 from os import symlink
 from subprocess import call
@@ -26,26 +24,22 @@ def move_environment_files_to_host():
     Move the json environment files to the host so they're editable.
     """
     if not ENVS_DIR.exists():
-        makedirs(ENVS_DIR)
+        raise Exception('Tahoe error: edxapp-envs is not checkout please run "make dev.clone" to correct the issue.')
 
     for filename in ENVIRONMENT_FILES:
         container_path = EDXAPP_ETC_DIR / filename
-        src_path = ENVS_DIR / filename  # The mounted directory in
+        src_path = ENVS_DIR / filename  # The mounted directory in devstack
 
         if not src_path.exists():
-            if container_path.islink():
-                raise Exception(
-                    'Unable to correctly move the environmet files, please shut down the '
-                    'container `$ make down` and try again with `$ make dev.up`'
-                )
+            raise Exception((
+                'Unable to correctly locale the edxapp-envs/{file}. Please run "make dev.clone" '
+                'to correct the issue then `$ make down` and `$ make dev.up`.'
+            ).format(file=src_path))
 
-            move(container_path, src_path)
-
-        if src_path.exists():
-            if container_path.exists():
-                container_path.unlink()
-            if not container_path.islink():
-                symlink(src_path, container_path)
+        if container_path.exists():
+            container_path.unlink()
+        if not container_path.islink():
+            symlink(src_path, container_path)
 
 
 def install_auto_pip_requirements():

--- a/repo.sh
+++ b/repo.sh
@@ -39,6 +39,7 @@ repos=(
     "git@github.com:appsembler/edx-theme-codebase.git"
     "git@github.com:appsembler/edx-theme-customers.git"
     "git@github.com:appsembler/edx-platform.git"
+    "git@github.com:appsembler/edxapp-envs.git"
     "https://github.com/edx/xqueue.git"
     "https://github.com/edx/edx-analytics-pipeline.git"
     "https://github.com/edx/frontend-app-gradebook.git"
@@ -59,6 +60,7 @@ ssh_repos=(
     "git@github.com:edx/edx-e2e-tests.git"
     "git@github.com:edx/edx-notes-api.git"
     "git@github.com:appsembler/edx-platform.git"
+    "git@github.com:appsembler/edxapp-envs.git"
     "git@github.com:edx/xqueue.git"
     "git@github.com:edx/edx-analytics-pipeline.git"
     "git@github.com:edx/frontend-app-gradebook.git"
@@ -102,6 +104,11 @@ _checkout ()
             cd "$name"
             _appsembler_checkout_and_update_branch "$name"
             cd ..
+        elif [ "$name" == "edxapp-envs" ] && [ -d "src/edxapp-envs/.git" ]; then
+            echo "Checking out branch ${OPENEDX_GIT_BRANCH} of $name"
+            cd src/edxapp-envs
+            _appsembler_checkout_and_update_branch "$name"
+            cd ../..
         elif [ "$name" == "edx-theme-customers" ] && [ -d "edx-theme-codebase/customer_specific/.git" ]; then
             echo "Checking out branch ${OPENEDX_GIT_BRANCH} of $name"
             cd edx-theme-codebase/customer_specific
@@ -139,8 +146,14 @@ _clone ()
             _appsembler_checkout_and_update_branch $name
             cd ..
         elif [ "$name" == "edx-theme-customers" ] && [ -d "edx-theme-codebase/customer_specific/.git" ]; then
+            printf "The [%s] repo is already checked out. Checking for updates.\n" "$name"
             cd "${DEVSTACK_WORKSPACE}/edx-theme-codebase/customer_specific"
             _appsembler_checkout_and_update_branch $name
+            cd ../..
+        elif [ "$name" == "edxapp-envs" ] && [ -d "src/edxapp-envs/.git" ]; then
+            printf "The [%s] repo is already checked out. Checking for updates.\n" "$name"
+            cd "${DEVSTACK_WORKSPACE}/src/edxapp-envs"
+            _appsembler_checkout_and_update_branch "$name"
             cd ../..
         else
             if [ "$name" == "edx-platform" ]; then
@@ -153,6 +166,9 @@ _clone ()
                 cd edx-theme-codebase
                 sudo rm -rf customer_specific
                 git clone -b ${THEME_CUSTOMERS_BRANCH} -c core.symlinks=true ${repo} customer_specific
+            elif [ "$name" == "edxapp-envs" ]; then
+                sudo rm -rf "${DEVSTACK_WORKSPACE}/src/edxapp-envs"
+                git clone -b ${OPENEDX_GIT_BRANCH} -c core.symlinks=true ${repo} "${DEVSTACK_WORKSPACE}/src/edxapp-envs"
             else
                 if [ "${SHALLOW_CLONE}" == "1" ]; then
                     git clone --single-branch -b ${OPENEDX_GIT_BRANCH} -c core.symlinks=true --depth=1 ${repo}
@@ -227,6 +243,8 @@ reset ()
                 cd $name;git reset --hard HEAD;git checkout ${THEME_CODEBASE_BRANCH};git reset --hard origin/${THEME_CODEBASE_BRANCH};git pull;cd "$currDir"
             elif [ "$name" == "edx-theme-customers" ]; then
                 cd edx-theme-codebase/customer_specific;git reset --hard HEAD;git checkout ${THEME_CUSTOMERS_BRANCH};git reset --hard origin/${THEME_CUSTOMERS_BRANCH};git pull;cd "$currDir"
+            elif [ "$name" == "edxapp-envs" ]; then
+                cd src/edxapp-envs;git reset --hard HEAD;git checkout ${OPENEDX_GIT_BRANCH};git reset --hard origin/${OPENEDX_GIT_BRANCH};git pull;cd "$currDir"
             elif [ "$name" == "amc" ]; then
                 cd $name;git reset --hard HEAD;git checkout ${AMC_BRANCH};git reset --hard origin/${AMC_BRANCH};git pull;cd "$currDir"
             else


### PR DESCRIPTION
This pull request integrates https://github.com/appsembler/edxapp-envs in devstack to create shared configuration and make devstack configs ready out of the box.

This was made to address failures in new builds (both native and Sultan's) in which configurations are outdated.

The `edxapp-envs` repo has the main branch set to `open-release/juniper.master` to match edX's variable `OPENEDX_GIT_BRANCH`.