### PR TITLE
add amc-update-db: fixes error in devstack `make dev.reset`

### DIFF
--- a/tahoe.mk
+++ b/tahoe.mk
@@ -48,3 +48,6 @@ amc-frontend-shell:
 amc-restart:
 	docker exec -t tahoe.$(COMPOSE_PROJECT_NAME).amc bash -c 'killall5'
 	docker exec -t tahoe.$(COMPOSE_PROJECT_NAME).amc-frontend bash -c 'killall5'
+
+amc-update-db:
+	docker exec -t tahoe.$(COMPOSE_PROJECT_NAME).amc bash -c './manage.py migrate'


### PR DESCRIPTION
More fixes for `make dev.reset` RED-2047.

This replaces the generic `%-update-db` Makefile rule which fails for AMC with an AMC-specific one that works.

```
docker-compose -f docker-compose.yml -f docker-compose-host.yml -f docker-compose-themes.yml -f docker-compose-watchers.yml -f docker-compose-xqueue.yml -f docker-compose-analytics-pipeline.yml -f docker-compose-marketing-site.yml exec amc bash -c 'source /edx/app/amc/amc_env && cd /edx/app/amc/amc/ && make migrate'
[sudo] password for omar: 
bash: /edx/app/amc/amc_env: No such file or directory
make: *** [Makefile:316: amc-update-db] Error 1
```